### PR TITLE
Add assertions for running commands

### DIFF
--- a/src/main/java/retupmoc/Retupmoc.java
+++ b/src/main/java/retupmoc/Retupmoc.java
@@ -65,20 +65,25 @@ public class Retupmoc {
         case "list":
             yield ui.displayList(list);
         case "mark":
+            assert !command.parameters.isEmpty();
             yield markTaskDone(Integer.parseInt(command.parameters.get(0)));
         case "unmark":
+            assert !command.parameters.isEmpty();
             yield markTaskNotDone(Integer.parseInt(command.parameters.get(0)));
         case "bye":
             yield ui.printGoodbye();
         case "todo":
+            assert !command.parameters.isEmpty();
             yield addTask(new ToDo(command.parameters.get(0)));
         case "deadline":
+            assert command.parameters.size() >= 2;
             try {
                 yield addTask(new Deadline(command.parameters.get(0), command.parameters.get(1)));
             } catch (DateTimeParseException e) {
                 throw new RetupmocException("Date format should be " + Deadline.INPUT_FORMAT + ". Time is optional");
             }
         case "event":
+            assert command.parameters.size() >= 3;
             try {
                 yield addTask(
                         new Event(
@@ -91,8 +96,10 @@ public class Retupmoc {
                 throw new RetupmocException("Date format should be " + Deadline.INPUT_FORMAT + ". Time is optional");
             }
         case "delete":
+            assert !command.parameters.isEmpty();
             yield removeTask(Integer.parseInt(command.parameters.get(0)));
         case "find":
+            assert !command.parameters.isEmpty();
             yield ui.displayList(list.findTasks(command.parameters.get(0)));
         default:
             throw new RetupmocException("Unknown command: " + command.commandType);

--- a/src/main/java/retupmoc/command/CommandParser.java
+++ b/src/main/java/retupmoc/command/CommandParser.java
@@ -66,6 +66,8 @@ public class CommandParser {
             return List.of(String.valueOf(Integer.parseInt(tokens[1]) - 1));
         } catch (NumberFormatException e) {
             throw new RetupmocException("Invalid task number");
+        } catch (IndexOutOfBoundsException e) {
+            throw new RetupmocException("No task specified");
         }
     }
 


### PR DESCRIPTION
The method runCommand executes the parsed command, which contains a list of Strings as command parameters, without checking whether there are enough parameters in the parsed command. This can cause bugs if the command parser does not correctly parse the user input.

Assertions have been added at the start of runCommand to check whether the command has enough parameters for that command type.

Assertions are used instead of Exceptions or error handling as runCommand is a private method and is only called with valid commands, unless there is a bug in parsing the command.